### PR TITLE
Update admin04_feiertage_edit.php

### DIFF
--- a/include/class_feiertage.php
+++ b/include/class_feiertage.php
@@ -118,7 +118,7 @@ class time_feiertage
 			$_datum= $_POST['v'.$x];
 			if($_name <> "" && $_datum <> ""){
 				$_datum = explode(".", $_datum);
-				$_datum2= mktime(0,0,0,$_datum[1],$_datum[0],0);
+				$_datum2= mktime(0,0,0,$_datum[1],$_datum[0],$_datum[2]);
 				$_tmparr[$x] = $_name.";".$_datum2;
 			}
 		}

--- a/include/class_feiertage.php
+++ b/include/class_feiertage.php
@@ -50,7 +50,7 @@ class time_feiertage
 		$_userfeiertage = file($this->_file);
 		foreach($_userfeiertage as $_eintrag){
 			$_eintrag = explode(";", $_eintrag);
-			$_datum   = date('d.n', $_eintrag[1]);
+			$_datum   = date('d.n.Y', $_eintrag[1]);
 			$_datum   = explode(".", $_datum);
 			$_datum   = mktime(0,0,0,$_datum[1],$_datum[0],$_datum[2]) ;
 			$holidays[$_eintrag[0]] = $_datum;

--- a/include/class_feiertage.php
+++ b/include/class_feiertage.php
@@ -142,7 +142,7 @@ class time_feiertage
 		$x       = 0;
 		foreach($_tmparr as $_zeile){
 			$_tmparr[$x] = explode(";", $_tmparr[$x]);
-			$_tmparr[$x][1] = date('d.n', $_tmparr[$x][1]);
+			$_tmparr[$x][1] = date('d.n.Y', $_tmparr[$x][1]);
 			$x++;
 		}
 		return $_tmparr;

--- a/include/class_feiertage.php
+++ b/include/class_feiertage.php
@@ -52,7 +52,7 @@ class time_feiertage
 			$_eintrag = explode(";", $_eintrag);
 			$_datum   = date('d.n', $_eintrag[1]);
 			$_datum   = explode(".", $_datum);
-			$_datum   = mktime(0,0,0,$_datum[1],$_datum[0],$year) ;
+			$_datum   = mktime(0,0,0,$_datum[1],$_datum[0],$_datum[2]) ;
 			$holidays[$_eintrag[0]] = $_datum;
 		}
 		return $holidays;

--- a/include/class_filehandle.php
+++ b/include/class_filehandle.php
@@ -224,7 +224,7 @@ class time_filehandle{
 		$text = 'Vorname Nachname' ; 
 		fputs($fp, $text.$_zeilenvorschub);
 		//Start-Datum auf den jetztigen Monat setzten
-		$text = mktime(0, 0, 0, date("n", time()), 1, date("Y", time())); ;
+		$text = mktime(0, 0, 0, date("n", time()), date("j", time()), date("Y", time())); ;
 		fputs($fp, $text.$_zeilenvorschub);
 		$text = '100' ;
 		fputs($fp, $text.$_zeilenvorschub);

--- a/modules/sites_admin/admin04_feiertage_edit.php
+++ b/modules/sites_admin/admin04_feiertage_edit.php
@@ -17,7 +17,7 @@ echo '<td class="td_background_top" align="left">';
 echo 'Names des Feiertags.';
 echo '</td>';
 echo '<td class="td_background_top">';
-echo 'Datum (Tag.Monat)';
+echo 'Datum (Tag.Monat.Yahr)';
 echo '</td>';
 echo '</tr>';
 $i = 0;


### PR DESCRIPTION
I have added the description that you should use the format day.month.year because its important for some specific holidays that aren't always at the same date every year.